### PR TITLE
复制内容至系统粘贴板

### DIFF
--- a/utilcode/src/main/java/com/blankj/utilcode/utils/UnclassifiedUtils.java
+++ b/utilcode/src/main/java/com/blankj/utilcode/utils/UnclassifiedUtils.java
@@ -37,4 +37,22 @@ public class UnclassifiedUtils {
         }
         return false;
     }
+    
+    /**
+     * 复制内容至系统粘贴板
+     */
+    public static void copy(String content) {
+        if (content == null) return;
+        try {
+            // Gets a handle to the clipboard service.
+            ClipboardManager clipboard = (ClipboardManager)
+                    App.getInstance().getApplicationContext().getSystemService(Context.CLIPBOARD_SERVICE);
+            // Creates a new text clip to put on the clipboard
+            ClipData clip = ClipData.newPlainText("simple text", content);
+            clipboard.setPrimaryClip(clip);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+    
 }


### PR DESCRIPTION
在调试的时候比较有用(因为很长字的字符串被分行后打印出的log会夹杂tag)。