### PR TITLE
fix FileUtils.getFileExtension()

### DIFF
--- a/utilcode/src/main/java/com/blankj/utilcode/utils/FileUtils.java
+++ b/utilcode/src/main/java/com/blankj/utilcode/utils/FileUtils.java
@@ -1086,6 +1086,6 @@ public class FileUtils {
         int lastPoi = filePath.lastIndexOf('.');
         int lastSep = filePath.lastIndexOf(File.separator);
         if (lastPoi == -1 || lastSep >= lastPoi) return "";
-        return filePath.substring(lastPoi);
+        return filePath.substring(lastPoi+1);
     }
 }


### PR DESCRIPTION
修复由于获取文件拓展名错误，导致的一系列问题（如6.0安装APK异常）