### PR TITLE
兼容7.0下安装app

### DIFF
--- a/utilcode/src/main/java/com/blankj/utilcode/util/AppUtils.java
+++ b/utilcode/src/main/java/com/blankj/utilcode/util/AppUtils.java
@@ -50,6 +50,16 @@ public final class AppUtils {
     }
 
     /**
+     * 安装App(支持7.0)
+     *
+     * @param context  上下文
+     * @param filePath 文件路径
+     */
+    public static void installApp(Context context, String filePath, String fileProvider) {
+        installApp(context, FileUtils.getFileByPath(filePath), fileProvider);
+    }
+
+    /**
      * 安装App（支持6.0）
      *
      * @param context 上下文
@@ -58,6 +68,18 @@ public final class AppUtils {
     public static void installApp(Context context, File file) {
         if (!FileUtils.isFileExists(file)) return;
         context.startActivity(IntentUtils.getInstallAppIntent(file));
+    }
+
+    /**
+     * 安装App（支持6.0）
+     *
+     * @param context 上下文
+     * @param file    文件
+     * @param fileProvider fileProvider字符串
+     */
+    public static void installApp(Context context, File file, String fileProvider) {
+        if (!FileUtils.isFileExists(file)) return;
+        context.startActivity(IntentUtils.getInstallAppIntent(file, fileProvider));
     }
 
     /**

--- a/utilcode/src/main/java/com/blankj/utilcode/util/IntentUtils.java
+++ b/utilcode/src/main/java/com/blankj/utilcode/util/IntentUtils.java
@@ -42,6 +42,17 @@ public final class IntentUtils {
      * @return intent
      */
     public static Intent getInstallAppIntent(File file) {
+        return getInstallAppIntent(file, "com.your.package.fileProvider");
+    }
+
+    /**
+     * 获取安装App(支持7.0)的意图
+     *
+     * @param file 文件
+     * @param fileProvider fileProvider字符串
+     * @return intent
+     */
+    public static Intent getInstallAppIntent(File file, String fileProvider) {
         if (file == null) return null;
         Intent intent = new Intent(Intent.ACTION_VIEW);
         String type;
@@ -53,10 +64,11 @@ public final class IntentUtils {
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-            Uri contentUri = FileProvider.getUriForFile(Utils.getContext(), "com.your.package.fileProvider", file);
+            Uri contentUri = FileProvider.getUriForFile(Utils.getContext(), fileProvider, file);
             intent.setDataAndType(contentUri, type);
+        } else {
+            intent.setDataAndType(Uri.fromFile(file), type);
         }
-        intent.setDataAndType(Uri.fromFile(file), type);
         return intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
     }
 


### PR DESCRIPTION
原来的需要copy工具类过去自己配置fileprovider才能用…而且也存在逻辑上的问题
```java
// 这个setDataAndType原来是放在外层的
intent.setDataAndType(Uri.fromFile(file), type);
```
现在不需要copy工具类也能直接运行了