### PR TITLE
添加shell返回换行

### DIFF
--- a/utilcode/src/main/java/com/blankj/utilcode/util/ShellUtils.java
+++ b/utilcode/src/main/java/com/blankj/utilcode/util/ShellUtils.java
@@ -114,8 +114,8 @@ public final class ShellUtils {
                 errorResult = new BufferedReader(new InputStreamReader(process.getErrorStream(), "UTF-8"));
                 String s;
                 while ((s = successResult.readLine()) != null) {
-                    successMsg.append("\n");
-                    successMsg.append(s);
+                    successMsg.append(System.getProperty("line.separator"));
+                    successMsg.append(System.getProperty("line.separator"));
                 }
                 while ((s = errorResult.readLine()) != null) {
                     errorMsg.append("\n");

--- a/utilcode/src/main/java/com/blankj/utilcode/util/ShellUtils.java
+++ b/utilcode/src/main/java/com/blankj/utilcode/util/ShellUtils.java
@@ -114,9 +114,11 @@ public final class ShellUtils {
                 errorResult = new BufferedReader(new InputStreamReader(process.getErrorStream(), "UTF-8"));
                 String s;
                 while ((s = successResult.readLine()) != null) {
+                    successMsg.append("\n");
                     successMsg.append(s);
                 }
                 while ((s = errorResult.readLine()) != null) {
+                    errorMsg.append("\n");
                     errorMsg.append(s);
                 }
             }


### PR DESCRIPTION
shell结果换行。
之前的结果会将shell返回后的字符串拼接在一起，如果使用ls 、ps等这样的命令导致输出的文件夹都拼接在一起无法友好的查看，也不符合命令输出的格式。