### PR TITLE
Null-checks for @NonNull method arguments

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,6 @@
+plugins {
+    id "tech.harmonysoft.oss.traute" version '1.0.5'
+}
 apply plugin: 'com.android.application'
 
 File signPropertiesFile = rootProject.file('sign/keystore.properties')
@@ -46,6 +49,9 @@ android {
     }
 }
 
+traute {
+    javacPluginVersion = trauteVersion
+}
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ ext {
 
     junit_version = '4.12'
     robolectric_version = '3.1.2'
+
+    trauteVersion = '1.0.10'
 }
 
 

--- a/subutil/build.gradle
+++ b/subutil/build.gradle
@@ -1,3 +1,6 @@
+plugins {
+    id "tech.harmonysoft.oss.traute" version '1.0.5'
+}
 apply plugin: 'com.android.library'
 apply plugin: 'jacoco'
 
@@ -48,6 +51,10 @@ android {
             events 'passed', 'skipped', 'failed', 'standardOut', 'standardError'
         }
     }
+}
+
+traute {
+    javacPluginVersion = trauteVersion
 }
 
 dependencies {

--- a/utilcode/build.gradle
+++ b/utilcode/build.gradle
@@ -1,3 +1,6 @@
+plugins {
+    id "tech.harmonysoft.oss.traute" version '1.0.5'
+}
 apply plugin: 'com.android.library'
 apply plugin: 'jacoco'
 
@@ -47,6 +50,10 @@ android {
             events 'passed', 'skipped', 'failed', 'standardOut', 'standardError'
         }
     }
+}
+
+traute {
+    javacPluginVersion = trauteVersion
 }
 
 dependencies {


### PR DESCRIPTION
This *PR* applies [Traute](http://traute.oss.harmonysoft.tech/) *javac* plugin to the project in order to have runtime *null*-checks for method parameters marked by *NonNull* annotation.  

E.g. consider [BaseDrawerActivity.$1. onNavigationItemSelected()](https://github.com/Blankj/AndroidUtilCode/blob/master/app/src/main/java/com/blankj/androidutilcode/base/BaseDrawerActivity.java#L32). Resulting bytecode looks like if it's compiled from the source below:  

```java
public boolean onNavigationItemSelected(@NonNull MenuItem item) {
    if (item == null) {
        throw new NullPointerException("String Argument 'item' of type MenuItem (#0 out of 1, zero-based) is marked by @android.support.annotation.NonNull but got null for it");
    }
    switch (item.getItemId()) {
    ...
```
Here are the details:  

*app/BaseDrawerActivity$1*  

```
javap -c ./app/build/intermediates/classes/release/com/blankj/androidutilcode/base/BaseDrawerActivity\$1.class
...
  public boolean onNavigationItemSelected(android.view.MenuItem);
    Code:
       0: aload_1
       1: ifnonnull     14
       4: new           #3                  // class java/lang/NullPointerException
       7: dup
       8: ldc           #4                  // String Argument 'item' of type MenuItem (#0 out of 1, zero-based) is marked by @android.support.annotation.NonNull but got null for it
      10: invokespecial #5                  // Method java/lang/NullPointerException."<init>":(Ljava/lang/String;)V
      13: athrow
```

*subutil/Utils*  

```
javap -c ./subutil/build/intermediates/classes/release/com/blankj/subutil/util/Utils.class
...
  public static void init(android.content.Context);
    Code:
       0: aload_0
       1: ifnonnull     14
       4: new           #5                  // class java/lang/NullPointerException
       7: dup
       8: ldc           #6                  // String Argument 'context' of type Context (#0 out of 1, zero-based) is marked by @android.support.annotation.NonNull but got null for it
      10: invokespecial #7                  // Method java/lang/NullPointerException."<init>":(Ljava/lang/String;)V
      13: athrow
```  

*utilcode/ActivityUtils*  

```
javap -c ./utilcode/build/intermediates/classes/release/com/blankj/utilcode/util/ActivityUtils.class
...
 public static boolean isActivityExists(java.lang.String, java.lang.String);
    Code:
       0: aload_0
       1: ifnonnull     14
       4: new           #5                  // class java/lang/NullPointerException
       7: dup
       8: ldc           #6                  // String Argument 'packageName' of type String (#0 out of 2, zero-based) is marked by @android.support.annotation.NonNull but got null for it
      10: invokespecial #7                  // Method java/lang/NullPointerException."<init>":(Ljava/lang/String;)V
      13: athrow
```

TESTED: gradlew build & ensured that the checks are inserted