### PR TITLE
将Application改成Context

### DIFF
--- a/subutil/src/main/java/com/blankj/subutil/util/Utils.java
+++ b/subutil/src/main/java/com/blankj/subutil/util/Utils.java
@@ -1,7 +1,7 @@
 package com.blankj.subutil.util;
 
 import android.annotation.SuppressLint;
-import android.app.Application;
+import android.content.Context;
 import android.support.annotation.NonNull;
 
 /**
@@ -49,7 +49,7 @@ import android.support.annotation.NonNull;
 public final class Utils {
 
     @SuppressLint("StaticFieldLeak")
-    private static Application sApplication;
+    private static Context sContext;
 
     private Utils() {
         throw new UnsupportedOperationException("u can't instantiate me...");
@@ -58,10 +58,10 @@ public final class Utils {
     /**
      * 初始化工具类
      *
-     * @param app 应用
+     * @param context 应用
      */
-    public static void init(@NonNull final Application app) {
-        Utils.sApplication = app;
+    public static void init(@NonNull final Context context) {
+        Utils.sContext = context;
     }
 
     /**
@@ -69,8 +69,8 @@ public final class Utils {
      *
      * @return Application
      */
-    public static Application getApp() {
-        if (sApplication != null) return sApplication;
+    public static Context getApp() {
+        if (sContext != null) return sContext;
         throw new NullPointerException("u should init first");
     }
 }

--- a/utilcode/src/main/java/com/blankj/utilcode/util/Utils.java
+++ b/utilcode/src/main/java/com/blankj/utilcode/util/Utils.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Application;
 import android.app.Application.ActivityLifecycleCallbacks;
+import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 
@@ -56,7 +57,7 @@ import java.util.List;
 public final class Utils {
 
     @SuppressLint("StaticFieldLeak")
-    private static Application sApplication;
+    private static Context sContext;
 
     static WeakReference<Activity> sTopActivityWeakRef;
     static List<Activity> sActivityList = new LinkedList<>();
@@ -106,11 +107,14 @@ public final class Utils {
     /**
      * 初始化工具类
      *
-     * @param app 应用
+     * @param context 应用
      */
-    public static void init(@NonNull final Application app) {
-        Utils.sApplication = app;
-        app.registerActivityLifecycleCallbacks(mCallbacks);
+    public static void init(@NonNull final Context context) {
+        Utils.sContext = context;
+
+        if (context instanceof Application){
+            ((Application)context).registerActivityLifecycleCallbacks(mCallbacks);
+        }
     }
 
     /**
@@ -118,8 +122,8 @@ public final class Utils {
      *
      * @return Application
      */
-    public static Application getApp() {
-        if (sApplication != null) return sApplication;
+    public static Context getApp() {
+        if (sContext != null) return sContext;
         throw new NullPointerException("u should init first");
     }
 


### PR DESCRIPTION
更改原因：
由于开发环境的特殊，需要在用到`AndroidTest`下开发，但是找不到`Application`实例，只能找到Context。

改法，将init的Application改成Context。
我看到其实只有注册`registerActivityLifecycleCallbacks`才需要Application类型，因此这样改。


库是真好用~~~~~~哈哈希望采纳！或者在下个版本做下调整，改成Context传入。
