### PR TITLE
修改颜色加深不正确问题

### DIFF
--- a/lib/utilcode/src/main/java/com/blankj/utilcode/util/ClickUtils.java
+++ b/lib/utilcode/src/main/java/com/blankj/utilcode/util/ClickUtils.java
@@ -234,7 +234,7 @@ public class ClickUtils {
                 darkAlpha, 0, 0, 0, 0,
                 0, darkAlpha, 0, 0, 0,
                 0, 0, darkAlpha, 0, 0,
-                0, 0, 0, 2, 0
+                0, 0, 0, 1, 0
         }));
     }
 


### PR DESCRIPTION
调整亮度，alpha通道的值应该为1；
现在值为2，在Android9上表现正常，在Android9以下表现不正常，颜色变亮。