### PR TITLE
Fix: MessengerUtils:  IllegalStateException: message is already in use

### DIFF
--- a/lib/utilcode/src/main/java/com/blankj/utilcode/util/MessengerUtils.java
+++ b/lib/utilcode/src/main/java/com/blankj/utilcode/util/MessengerUtils.java
@@ -320,7 +320,7 @@ public class MessengerUtils {
             for (Messenger client : mClientMap.values()) {
                 try {
                     if (client != null) {
-                        client.send(msg);
+                        client.send(Message.obtain(msg));
                     }
                 } catch (RemoteException e) {
                     e.printStackTrace();


### PR DESCRIPTION
Fix: IllegalStateException: message is already in use
