### PR TITLE
isUsingNetworkProvidedTime()

### DIFF
--- a/lib/utilcode/src/main/java/com/blankj/utilcode/util/TimeUtils.java
+++ b/lib/utilcode/src/main/java/com/blankj/utilcode/util/TimeUtils.java
@@ -36,6 +36,19 @@ public final class TimeUtils {
     private static SimpleDateFormat getDefaultFormat() {
         return getSafeDateFormat("yyyy-MM-dd HH:mm:ss");
     }
+    /**
+     * Checks whether the device is using Network Provided Time or not.
+     *  Useful in situations where you want to verify that the device has a correct time set, to avoid fraud, or if you want to prevent the user from messing with the time and abusing your "one-time" and "expiring" features. 
+     * @return {@code true}: yes<br>{@code false}: no
+     */
+    public static boolean isUsingNetworkProvidedTime() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            return Settings.Global.getInt(Utils.getApp().getContentResolver(), Settings.Global.AUTO_TIME, 0) == 1;
+        } else {
+            return android.provider.Settings.System.getInt(Utils.getApp().getContentResolver(), android.provider.Settings.System.AUTO_TIME, 0) == 1;
+        }
+    }
+    
 
     @SuppressLint("SimpleDateFormat")
     public static SimpleDateFormat getSafeDateFormat(String pattern) {


### PR DESCRIPTION
Useful in situations where you want to verify that the device has a correct time set, to avoid fraud, or if you want to prevent the user from messing with the time and abusing your "one-time" and "expiring" features.