### PR TITLE
修复了一个内存泄漏的问题

### DIFF
--- a/lib/utilcode/src/main/java/com/blankj/utilcode/util/KeyboardUtils.java
+++ b/lib/utilcode/src/main/java/com/blankj/utilcode/util/KeyboardUtils.java
@@ -238,6 +238,8 @@ public final class KeyboardUtils {
         if (tag instanceof OnGlobalLayoutListener) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
                 contentView.getViewTreeObserver().removeOnGlobalLayoutListener((OnGlobalLayoutListener) tag);
+                //这里会发生内存泄漏 如果不设置为null
+                contentView.setTag(TAG_ON_GLOBAL_LAYOUT_LISTENER, null);
             }
         }
     }


### PR DESCRIPTION
   //这里会发生内存泄漏 如果不设置为null
                contentView.setTag(TAG_ON_GLOBAL_LAYOUT_LISTENER, null);