### PR TITLE
[M] AppUtils增加getAppMinSdkVersion, getAppTargetSdkVersion支持

### DIFF
--- a/feature/utilcode/pkg/src/main/java/com/blankj/utilcode/pkg/feature/app/AppActivity.kt
+++ b/feature/utilcode/pkg/src/main/java/com/blankj/utilcode/pkg/feature/app/AppActivity.kt
@@ -54,7 +54,10 @@ class AppActivity : CommonActivity(), Utils.OnAppStatusChangedListener {
 
     override fun bindItems(): MutableList<CommonItem<*>> {
         return CollectionUtils.newArrayList(
-                CommonItemSwitch("registerAppStatusChangedListener", { isRegisterAppStatusChangedListener }, {
+            CommonItemSwitch(
+                "registerAppStatusChangedListener",
+                { isRegisterAppStatusChangedListener },
+                {
                     isRegisterAppStatusChangedListener = it
                     if (it) {
                         AppUtils.registerAppStatusChangedListener(this)
@@ -62,55 +65,63 @@ class AppActivity : CommonActivity(), Utils.OnAppStatusChangedListener {
                         AppUtils.unregisterAppStatusChangedListener(this)
                     }
                 }),
-                CommonItemTitle("isAppRoot", AppUtils.isAppRoot().toString()),
-                CommonItemTitle("isAppDebug", AppUtils.isAppDebug().toString()),
-                CommonItemTitle("isAppSystem", AppUtils.isAppSystem().toString()),
-                CommonItemTitle("isAppForeground", AppUtils.isAppForeground(AppUtils.getAppPackageName()).toString()),
-                CommonItemTitle("isAppRunning", AppUtils.isAppRunning(AppUtils.getAppPackageName()).toString()),
-                CommonItemImage("getAppIcon") {
-                    it.setImageDrawable(AppUtils.getAppIcon())
-                },
-                CommonItemTitle("getAppPackageName", AppUtils.getAppPackageName()),
-                CommonItemTitle("getAppName", AppUtils.getAppName()),
-                CommonItemTitle("getAppPath", AppUtils.getAppPath()),
-                CommonItemTitle("getAppVersionName", AppUtils.getAppVersionName()),
-                CommonItemTitle("getAppVersionCode", AppUtils.getAppVersionCode().toString()),
-                CommonItemTitle("getAppSignaturesSHA1", AppUtils.getAppSignaturesSHA1().toString()),
-                CommonItemTitle("getAppSignaturesSHA256", AppUtils.getAppSignaturesSHA256().toString()),
-                CommonItemTitle("getAppSignaturesMD5", AppUtils.getAppSignaturesMD5().toString()),
-                CommonItemTitle("getAppUid", AppUtils.getAppUid().toString()),
-                CommonItemTitle("getApkInfo", AppUtils.getApkInfo(AppUtils.getAppPath()).toString()),
+            CommonItemTitle("isAppRoot", AppUtils.isAppRoot().toString()),
+            CommonItemTitle("isAppDebug", AppUtils.isAppDebug().toString()),
+            CommonItemTitle("isAppSystem", AppUtils.isAppSystem().toString()),
+            CommonItemTitle(
+                "isAppForeground",
+                AppUtils.isAppForeground(AppUtils.getAppPackageName()).toString()
+            ),
+            CommonItemTitle(
+                "isAppRunning",
+                AppUtils.isAppRunning(AppUtils.getAppPackageName()).toString()
+            ),
+            CommonItemImage("getAppIcon") {
+                it.setImageDrawable(AppUtils.getAppIcon())
+            },
+            CommonItemTitle("getAppPackageName", AppUtils.getAppPackageName()),
+            CommonItemTitle("getAppName", AppUtils.getAppName()),
+            CommonItemTitle("getAppPath", AppUtils.getAppPath()),
+            CommonItemTitle("getAppVersionName", AppUtils.getAppVersionName()),
+            CommonItemTitle("getAppVersionCode", AppUtils.getAppVersionCode().toString()),
+            CommonItemTitle("getAppMinSdkVersion", AppUtils.getAppMinSdkVersion().toString()),
+            CommonItemTitle("getAppTargetSdkVersion", AppUtils.getAppTargetSdkVersion().toString()),
+            CommonItemTitle("getAppSignaturesSHA1", AppUtils.getAppSignaturesSHA1().toString()),
+            CommonItemTitle("getAppSignaturesSHA256", AppUtils.getAppSignaturesSHA256().toString()),
+            CommonItemTitle("getAppSignaturesMD5", AppUtils.getAppSignaturesMD5().toString()),
+            CommonItemTitle("getAppUid", AppUtils.getAppUid().toString()),
+            CommonItemTitle("getApkInfo", AppUtils.getApkInfo(AppUtils.getAppPath()).toString()),
 
-                CommonItemClick(R.string.app_install) {
-                    if (AppUtils.isAppInstalled(Config.TEST_PKG)) {
-                        ToastUtils.showShort(R.string.app_install_tips)
+            CommonItemClick(R.string.app_install) {
+                if (AppUtils.isAppInstalled(Config.TEST_PKG)) {
+                    ToastUtils.showShort(R.string.app_install_tips)
+                } else {
+                    if (!FileUtils.isFileExists(Config.TEST_APK_PATH)) {
+                        ReleaseInstallApkTask(listener).execute()
                     } else {
-                        if (!FileUtils.isFileExists(Config.TEST_APK_PATH)) {
-                            ReleaseInstallApkTask(listener).execute()
-                        } else {
-                            listener.onReleased()
-                        }
+                        listener.onReleased()
                     }
-                },
-                CommonItemClick(R.string.app_uninstall) {
-                    if (AppUtils.isAppInstalled(Config.TEST_PKG)) {
-                        AppUtils.uninstallApp(Config.TEST_PKG)
-                    } else {
-                        ToastUtils.showShort(R.string.app_uninstall_tips)
-                    }
-                },
-                CommonItemClick(R.string.app_launch) {
-                    AppUtils.launchApp(this.packageName)
-                },
-                CommonItemClick(R.string.app_relaunch) {
-                    AppUtils.relaunchApp()
-                },
-                CommonItemClick(R.string.app_launch_details_settings, true) {
-                    AppUtils.launchAppDetailsSettings()
-                },
-                CommonItemClick(R.string.app_exit) {
-                    AppUtils.exitApp()
                 }
+            },
+            CommonItemClick(R.string.app_uninstall) {
+                if (AppUtils.isAppInstalled(Config.TEST_PKG)) {
+                    AppUtils.uninstallApp(Config.TEST_PKG)
+                } else {
+                    ToastUtils.showShort(R.string.app_uninstall_tips)
+                }
+            },
+            CommonItemClick(R.string.app_launch) {
+                AppUtils.launchApp(this.packageName)
+            },
+            CommonItemClick(R.string.app_relaunch) {
+                AppUtils.relaunchApp()
+            },
+            CommonItemClick(R.string.app_launch_details_settings, true) {
+                AppUtils.launchAppDetailsSettings()
+            },
+            CommonItemClick(R.string.app_exit) {
+                AppUtils.exitApp()
+            }
         )
     }
 
@@ -130,7 +141,8 @@ class AppActivity : CommonActivity(), Utils.OnAppStatusChangedListener {
     }
 }
 
-class ReleaseInstallApkTask(private val mListener: OnReleasedListener) : ThreadUtils.SimpleTask<Unit>() {
+class ReleaseInstallApkTask(private val mListener: OnReleasedListener) :
+    ThreadUtils.SimpleTask<Unit>() {
 
     override fun doInBackground() {
         ResourceUtils.copyFileFromAssets("test_install", Config.TEST_APK_PATH)

--- a/lib/utilcode/README-CN.md
+++ b/lib/utilcode/README-CN.md
@@ -72,6 +72,8 @@ getAppName                        : 获取 App 名称
 getAppPath                        : 获取 App 路径
 getAppVersionName                 : 获取 App 版本号
 getAppVersionCode                 : 获取 App 版本码
+getAppMinSdkVersion               : 获取 App 支持最低系统版本号
+getAppTargetSdkVersion            : 获取 App 目标系统版本号
 getAppSignatures                  : 获取 App 签名
 getAppSignaturesSHA1              : 获取应用签名的的 SHA1 值
 getAppSignaturesSHA256            : 获取应用签名的的 SHA256 值

--- a/lib/utilcode/README.md
+++ b/lib/utilcode/README.md
@@ -72,6 +72,8 @@ getAppName
 getAppPath
 getAppVersionName
 getAppVersionCode
+getAppMinSdkVersion
+getAppTargetSdkVersion
 getAppSignatures
 getAppSignaturesSHA1
 getAppSignaturesSHA256

--- a/lib/utildebug/src/main/java/com/blankj/utildebug/debug/tool/appInfo/AppInfoItem.java
+++ b/lib/utildebug/src/main/java/com/blankj/utildebug/debug/tool/appInfo/AppInfoItem.java
@@ -5,19 +5,18 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+
 import com.blankj.utilcode.util.AppUtils;
 import com.blankj.utilcode.util.ClickUtils;
 import com.blankj.utilcode.util.StringUtils;
-import com.blankj.utildebug.DebugUtils;
 import com.blankj.utildebug.R;
 import com.blankj.utildebug.base.rv.BaseItem;
 import com.blankj.utildebug.base.rv.ItemViewHolder;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.StringRes;
 
 /**
  * <pre>
@@ -29,8 +28,8 @@ import androidx.annotation.StringRes;
  */
 public class AppInfoItem extends BaseItem<AppInfoItem> {
 
-    private String          mTitle;
-    private String          mContent;
+    private String mTitle;
+    private String mContent;
     private OnClickListener mListener;
 
     private TextView titleTv;
@@ -71,9 +70,9 @@ public class AppInfoItem extends BaseItem<AppInfoItem> {
         appInfoItems.add(new AppInfoItem(R.string.du_app_info_version_name, AppUtils.getAppVersionName()));
         appInfoItems.add(new AppInfoItem(R.string.du_app_info_version_code, String.valueOf(AppUtils.getAppVersionCode())));
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            appInfoItems.add(new AppInfoItem(R.string.du_app_info_min_sdk_version, String.valueOf(DebugUtils.getApp().getApplicationInfo().minSdkVersion)));
+            appInfoItems.add(new AppInfoItem(R.string.du_app_info_min_sdk_version, String.valueOf(AppUtils.getAppMinSdkVersion())));
         }
-        appInfoItems.add(new AppInfoItem(R.string.du_app_info_target_sdk_version, String.valueOf(DebugUtils.getApp().getApplicationInfo().targetSdkVersion)));
+        appInfoItems.add(new AppInfoItem(R.string.du_app_info_target_sdk_version, String.valueOf(AppUtils.getAppTargetSdkVersion())));
         appInfoItems.add(new AppInfoItem(R.string.du_app_info_open_app_info_page, "", new OnClickListener() {
             @Override
             public void onClick(View v) {


### PR DESCRIPTION
AppUtils增加getAppMinSdkVersion, getAppTargetSdkVersion支持。

其中getAppMinSdkVersion方法有些特殊，
在Android 7.0以下设备运行时，返回-1，因为ApplicationInfo.minSdkVersion字段是在Android 7.0之后加入的，
在Android 7.0及以上设备运行时，返回正常。