### PR TITLE
如果应用开机自启动且没有打开的情况下被误判为在前台

### DIFF
--- a/lib/utilcode/src/main/java/com/blankj/utilcode/util/UtilsActivityLifecycleImpl.java
+++ b/lib/utilcode/src/main/java/com/blankj/utilcode/util/UtilsActivityLifecycleImpl.java
@@ -41,7 +41,7 @@ final class UtilsActivityLifecycleImpl implements Application.ActivityLifecycleC
 
     private int     mForegroundCount = 0;
     private int     mConfigCount     = 0;
-    private boolean mIsBackground    = false;
+    private boolean mIsBackground    = true;
 
     void init(Application app) {
         app.registerActivityLifecycleCallbacks(this);


### PR DESCRIPTION
mIsBackground的默认值应该为true,如果应用开启自启动但没有打开界面此时isAppForeground()方法错误的返回true