### PR TITLE
StatFs should catch IllegalArgumentException in case the specified pa…

### DIFF
--- a/lib/utilcode/src/main/java/com/blankj/utilcode/util/FileUtils.java
+++ b/lib/utilcode/src/main/java/com/blankj/utilcode/util/FileUtils.java
@@ -1412,7 +1412,13 @@ public final class FileUtils {
      */
     public static long getFsTotalSize(String anyPathInFs) {
         if (TextUtils.isEmpty(anyPathInFs)) return 0;
-        StatFs statFs = new StatFs(anyPathInFs);
+        StatFs statFs;
+        try {
+            statFs = new StatFs(anyPathInFs);
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+            return 0;
+        }
         long blockSize;
         long totalSize;
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR2) {
@@ -1433,7 +1439,13 @@ public final class FileUtils {
      */
     public static long getFsAvailableSize(final String anyPathInFs) {
         if (TextUtils.isEmpty(anyPathInFs)) return 0;
-        StatFs statFs = new StatFs(anyPathInFs);
+        StatFs statFs;
+        try {
+            statFs = new StatFs(anyPathInFs);
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+            return 0;
+        }
         long blockSize;
         long availableSize;
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR2) {

--- a/lib/utilcode/src/main/java/com/blankj/utilcode/util/SDCardUtils.java
+++ b/lib/utilcode/src/main/java/com/blankj/utilcode/util/SDCardUtils.java
@@ -73,6 +73,8 @@ public final class SDCardUtils {
                 e.printStackTrace();
             } catch (InvocationTargetException e) {
                 e.printStackTrace();
+            } catch (IllegalArgumentException e) {
+                e.printStackTrace();
             }
         } else {
             try {
@@ -100,6 +102,8 @@ public final class SDCardUtils {
             } catch (NoSuchMethodException e) {
                 e.printStackTrace();
             } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            } catch (IllegalArgumentException e) {
                 e.printStackTrace();
             }
         }


### PR DESCRIPTION
StatFs should catch IllegalArgumentException in case the specified path is not accessible especially for external storage like TF/SD cards. Otherwise it would crash the process.

Check the [crash report](https://github.com/Blankj/AndroidUtilCode/issues/1709)